### PR TITLE
 Posts should be formatted with line breaks

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
 <br>
 <br>
 <% @posts.each do |post| %>
-  <p><%= post.message %></p>
+  <p><%= simple_format(post.message) %></p>
 <% end %>
 
 <%= link_to new_post_path do %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,5 @@
 <%= form_for @post do |form| %>
   <%= form.label :message %>
-  <%= form.text_field :message %>
-
+  <%= form.text_area :message %>
   <%= form.submit "Submit" %>
 <% end %>

--- a/spec/features/posts_are_formatted_with_line_break_spec.rb
+++ b/spec/features/posts_are_formatted_with_line_break_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.feature "format post", type: :feature do
+  scenario "Postsshould be formatted with line breaks" do
+    visit "/users/sign_up"
+    fill_in "user[email]", with: "test@gmail.com"
+    fill_in "user[password]", with: "123456"
+    fill_in "user[password_confirmation]", with: "123456"
+    click_button "Sign up"
+    click_link "New post"
+    fill_in "Message", with: "Hello, world
+    this is a new line"
+    click_button "Submit"
+    expect(html).to include("br")
+  end
+
+  # scenario "If a user visits any page without signing in you are directed to sign up" do
+  # end
+end


### PR DESCRIPTION
A User can input posts with new lines.
Posts with new lines are displayed using line breaks on the user's posts page.