### PR TITLE
When visiting another user's wall and only that user's posts are displayed

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,7 @@ class PostsController < ApplicationController
   end
 
   def index
+    @user_class = User
     @posts = Post.all.order("created_at DESC")
     @user = User.all
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,6 +1,7 @@
 class UserController < ApplicationController
   def index
-    @posts = current_user.posts.order("created_at DESC")
+    @user_class = User
     @user = User.find(params[:id])
+    @posts = @user.posts.order("created_at DESC")
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,6 +8,9 @@
   <br>
   <% @posts.each do |post| %>
   <div>
+    <%= link_to user_path(post.user_id) do %>
+      <%= @user_class.find(post.user_id).email %>
+    <% end %>
     <p><%= simple_format(post.message) %></p>
     <p>Created at: <%= post.created_at.strftime("%b %-d %Y, %H:%M") %></p>
     <% if post.user_id == current_user.id %>  

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,11 +1,21 @@
 <% if user_signed_in? %>
-  <h1>Hello <%= current_user.email %>! You are now signed in to your User Page!</h1>
+  <% if current_user == @user %>
+    <h1>Hello <%= current_user.email %>! You are now signed in to your User Page!</h1>
+  <% else %>
+    <h1>This is <%= @user.email %>'s wall</h1> 
+  <% end %>
+  <%= link_to posts_path do %>
+    All Posts
+  <% end %>
   <p><%= link_to('Logout', destroy_user_session_path, method: :delete) %></p>
 <% end %>
 <br>
 <br>
 <% @posts.each do |post| %>
 <div>
+  <%= link_to user_path(post.user_id) do %>
+    <%= @user_class.find(post.user_id).email %>
+  <% end %>
   <p><%= simple_format(post.message) %></p>
   <p>Created at: <%= post.created_at.strftime("%b %-d %Y, %H:%M") %></p>
   <% if post.user_id == current_user.id %>

--- a/spec/features/displaying_posts_spec.rb
+++ b/spec/features/displaying_posts_spec.rb
@@ -23,4 +23,21 @@ RSpec.feature "Displaying Posts", type: :feature do
     sign_up_other_user
     expect(page).not_to have_content("Hello, this is User 1's post")
   end
+
+  feature "User Walls" do
+    scenario "A user can visit another user's wall and only that user's posts are displayed" do
+      sign_up
+      click_link "New post"
+      fill_in "Message", with: "Hello, this is User 1's post"
+      click_button "Submit"
+      click_link "Logout"
+      sign_up_other_user
+      click_link "New post"
+      fill_in "Message", with: "Hello, this is User 2's post"
+      click_button "Submit"
+      click_link "test@gmail.com"
+      expect(page).not_to have_content("Hello, this is User 2's post")
+      expect(page).to have_content("Hello, this is User 1's post")
+    end
+  end
 end


### PR DESCRIPTION
Added feature test for displaying posts on user walls.
Edited user pages to only display the current user's posts.
Added user id (email) to the top of post displays on user posts and all posts
Converted user id on posts to a link to that user's page
