### PR TITLE
User wall

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,20 +6,25 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.create(post_params.merge(user_id: current_user.id, wall_id: params[:wall_id]))
-    redirect_to posts_url
+    @wall_id = params[:wall_id]
+    redirect_home
   end
 
   def delete
     @post = Post.find(params[:format])
+    @wall_id = @post.wall_id
     @post.delete
-    redirect_to posts_url
+    redirect_home
   end
 
   def index
     @user_class = User
     @posts = Post.all.order("created_at DESC")
-    @user = User.all
-    
+    if @posts.first == nil
+      @wall_posts = @posts
+    else
+      @wall_posts = @posts.select { |post| post.wall_id == "" }
+    end
   end
 
   def edit
@@ -28,13 +33,22 @@ class PostsController < ApplicationController
 
   def update
     @post = Post.find(params[:id])
+    @wall_id = @post.wall_id
     if @post.update(params[:post].permit(:message))
-      redirect_to posts_url
+      redirect_home
     end
   end
 
   private
     def post_params
       params.require(:post).permit(:message)
+    end
+
+    def redirect_home
+      if @wall_id == ""
+        redirect_to posts_url
+      else
+        redirect_to user_url(@wall_id)
+      end
     end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,11 @@
 class PostsController < ApplicationController
   def new
     @post = Post.new
+    @wall_id = params[:user_id]
   end
 
   def create
-    @post = Post.create(post_params.merge(user_id: current_user.id))
+    @post = Post.create(post_params.merge(user_id: current_user.id, wall_id: params[:wall_id]))
     redirect_to posts_url
   end
 
@@ -18,6 +19,7 @@ class PostsController < ApplicationController
     @user_class = User
     @posts = Post.all.order("created_at DESC")
     @user = User.all
+    
   end
 
   def edit

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -2,6 +2,11 @@ class UserController < ApplicationController
   def index
     @user_class = User
     @user = User.find(params[:id])
-    @posts = @user.posts.order("created_at DESC")
+    @posts = Post.all.order("created_at DESC")
+    if @posts.first == nil
+      @select_posts = @posts
+    else
+      @select_posts = @posts.select { |post| post.wall_id == params[:id]}
+    end
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -4,9 +4,9 @@ class UserController < ApplicationController
     @user = User.find(params[:id])
     @posts = Post.all.order("created_at DESC")
     if @posts.first == nil
-      @select_posts = @posts
+      @wall_posts = @posts
     else
-      @select_posts = @posts.select { |post| post.wall_id == params[:id]}
+      @wall_posts = @posts.select { |post| post.wall_id == params[:id] }
     end
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
   <%= link_to user_path(current_user.id), class: 'btn btn-primary' do %>
     My Posts
   <% end %>
-    <%= link_to new_user_post_path(current_user.id), class: 'btn btn-primary' do %>
+    <%= link_to "/posts/new", class: 'btn btn-primary' do %>
     New post
   <% end %>
   <br>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,10 +17,10 @@
        <% end %>
       <%= simple_format(post.message, class: 'card-text') %>
       <p>Created at: <%= post.created_at.strftime("%b %-d %Y, %H:%M") %></p>
-      <% if post.user_id == current_user.id %>  
-        <%= link_to 'Delete', posts_path(post), method: :delete, class: 'btn btn-primary' %> 
+      <% if post.user_id == current_user.id %>
+        <%= link_to 'Delete', posts_path(post), method: :delete, class: 'btn btn-primary' %>
       <% end %>
-      <% if Time.now <= post.created_at + 600 && post.user_id == current_user.id %>  
+      <% if Time.now <= post.created_at + 600 && post.user_id == current_user.id %>
         <%= link_to 'posts/' + post.id.to_s, class: 'btn btn-primary' do %>
           Update
         <% end %>
@@ -33,19 +33,19 @@
   <h2>Sign up</h2>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
-  
+
     <div class="field">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
-  
+
     <div class="field">
       <%= f.label :password %>
       <em>(6 characters minimum)</em>
     <br />
       <%= f.password_field :password, autocomplete: "new-password" %>
     </div>
-  
+
     <div class="field">
       <%= f.label :password_confirmation %><br />
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,7 +9,7 @@
   <% end %>
   <br>
   <br>
-  <% @posts.each do |post| %>
+  <% @wall_posts.each do |post| %>
   <div class="card">
     <div class="card-body">
       <%= link_to user_path(post.user_id) do %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,6 @@
 <%= form_for @post do |form| %>
   <%= form.label :message %>
   <%= form.text_area :message %>
+  <input type="hidden" name="wall_id" value=<%= @wall_id %>>
   <%= form.submit "Submit" %>
 <% end %>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 <%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'btn btn-primary') %>
 
-<%= link_to new_user_post_path(current_user.id), class: 'btn btn-primary' do %>
+<%= link_to new_user_post_path(@user.id), class: 'btn btn-primary' do %>
   New post
 <% end %>
 

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -15,7 +15,7 @@
 
 <br>
 <br>
-<% @select_posts.each do |post| %>
+<% @wall_posts.each do |post| %>
   <div class="card">
     <div class="card-body">
       <%= link_to user_path(post.user_id) do %>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,7 +1,7 @@
 <% if current_user == @user %>
     <h1>Hello <%= current_user.email %>! You are now signed in to your User Page!</h1>
 <% else %>
-  <h1>This is <%= @user.email %>'s wall</h1> 
+  <h1>This is <%= @user.email %>'s wall</h1>
 <% end %>
 
 <%= link_to posts_path do %>
@@ -15,7 +15,7 @@
 
 <br>
 <br>
-<% @posts.each do |post| %>
+<% @select_posts.each do |post| %>
   <div class="card">
     <div class="card-body">
       <%= link_to user_path(post.user_id) do %>

--- a/db/migrate/20190918161219_add_wall_id_to_posts.rb
+++ b/db/migrate/20190918161219_add_wall_id_to_posts.rb
@@ -1,0 +1,5 @@
+class AddWallIdToPosts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :posts, :wall_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190912113117) do
+ActiveRecord::Schema.define(version: 20190918161219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190912113117) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "wall_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe PostsController, type: :controller do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe "DELETE /" do
+    it "responds with 200" do
+      user = User.create(email: "new@gmail.com", password: "password", password_confirmation: "password")
+      sign_in user
+      post :create, params: { post: { message: "Hello, world!" }, wall_id: "" }
+      delete :delete, format: user.posts.first.id
+      expect(Post.find_by(message: "Hello, world!")).not_to be
+    end
+  end
+
+  describe "POST /update " do
+    it "updates a post" do
+      user = User.create(email: "new@gmail.com", password: "password", password_confirmation: "password")
+      sign_in user
+      post :create, params: { post: { message: "Hello, world!" }, wall_id: "" }
+      post :update, params: { id: user.posts.first.id.to_s, post: { message: "Goodbye, world!" }, use_route: "/user/" + user.id.to_s + "/posts/" + user.posts.first.id.to_s + "/edit" }
+      expect(Post.find_by(message: "Hello, world!")).not_to be
+      expect(Post.find_by(message: "Goodbye, world!")).to be
+    end
+  end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe PostsController, type: :controller do
     it "responds with 200" do
       user = User.create(email: "new@gmail.com", password: "password", password_confirmation: "password")
       sign_in user
-      post :create, params: { post: { message: "Hello, world!" } }
+      post :create, params: { post: { message: "Hello, world!" }, wall_id: "" }
       expect(response).to redirect_to(posts_url)
     end
 
     it "creates a post" do
       user = User.create(email: "new@gmail.com", password: "password", password_confirmation: "password")
       sign_in user
-      post :create, params: { post: { message: "Hello, world!" } }
+      post :create, params: { post: { message: "Hello, world!" }, wall_id: "" }
       expect(Post.find_by(message: "Hello, world!")).to be
     end
   end

--- a/spec/features/deleting_posts_spec.rb
+++ b/spec/features/deleting_posts_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Deleting Posts", type: :feature do
   scenario "Delete posts link exists" do
     sign_up
+    click_link "All Posts"
     click_link "New post"
     fill_in "Message", with: "Hello, this is message 1"
     click_button "Submit"

--- a/spec/features/deleting_posts_spec.rb
+++ b/spec/features/deleting_posts_spec.rb
@@ -25,4 +25,18 @@ RSpec.feature "Deleting Posts", type: :feature do
     expect(page).to have_content("Hello, this is message 1")
     expect(page).not_to have_content("Howdy, I'm message 2")
   end
+
+  scenario "Users can delete posts from the global wall" do
+    sign_up
+    click_link "All Posts"
+    click_link "New post"
+    fill_in "Message", with: "Hello, this is message 1"
+    click_button "Submit"
+    click_link "New post"
+    fill_in "Message", with: "Howdy, I'm message 2"
+    click_button "Submit"
+    click_link("Delete", match: :first)
+    expect(page).to have_content("Hello, this is message 1")
+    expect(page).not_to have_content("Howdy, I'm message 2")
+  end
 end

--- a/spec/features/displaying_posts_spec.rb
+++ b/spec/features/displaying_posts_spec.rb
@@ -25,19 +25,31 @@ RSpec.feature "Displaying Posts", type: :feature do
   end
 
   feature "User Walls" do
-    scenario "A user can visit another user's wall and only that user's posts are displayed" do
+    scenario "Posts are only displayed on the wall they are created on" do
+      sign_up
+      click_link "All Posts"
+      click_link "New post"
+      fill_in "Message", with: "Hello, this is a global post"
+      click_button "Submit"
+      click_link "My Posts"
+      click_link "New post"
+      fill_in "Message", with: "Hello, this is a post on my wall"
+      click_button "Submit"
+      expect(page).not_to have_content("Hello, this is a global post")
+      expect(page).to have_content("Hello, this is a post on my wall")
+    end
+
+    scenario "When posting on the main wall posts are only displayed there." do
       sign_up
       click_link "New post"
-      fill_in "Message", with: "Hello, this is User 1's post"
+      fill_in "Message", with: "Hello, this is on my wall"
       click_button "Submit"
-      click_link "Logout"
-      sign_up_other_user
+      click_link "All Posts"
       click_link "New post"
-      fill_in "Message", with: "Hello, this is User 2's post"
+      fill_in "Message", with: "Hello, this is on the global wall"
       click_button "Submit"
-      click_link "test@gmail.com"
-      expect(page).not_to have_content("Hello, this is User 2's post")
-      expect(page).to have_content("Hello, this is User 1's post")
+      expect(page).not_to have_content("Hello, this is on my wall")
+      expect(page).to have_content("Hello, this is on the global wall")
     end
   end
 end

--- a/spec/features/submiting_posts_spec.rb
+++ b/spec/features/submiting_posts_spec.rb
@@ -19,4 +19,25 @@ RSpec.feature "Submitting Posts", type: :feature do
     sign_up_other_user
     expect(page).not_to have_content("Hello, this is user 1")
   end
+
+  scenario "User 2 creates post on User 1's wall, post shows on User 1 wall" do
+    # create User 1
+    sign_up
+    click_link "New post"
+    fill_in "Message", with: "Hello, this is user 1"
+    click_button "Submit"
+    click_link "Logout"
+    # create User 2
+    sign_up_other_user
+    click_link "All Posts"
+    # User 2 goes onto Wall of User 1
+    click_link "test@gmail.com"
+    click_link "New post"
+    fill_in "Message", with: "This is user 2, posting on user 1's wall"
+    click_button "Submit"
+    click_link "test@gmail.com"
+    expect(page).to have_content("This is user 2, posting on user 1's wall")
+    click_link "test_other@gmail.com"
+    expect(page).not_to have_content("This is user 2, posting on user 1's wall")
+  end
 end

--- a/spec/features/submiting_posts_spec.rb
+++ b/spec/features/submiting_posts_spec.rb
@@ -21,21 +21,18 @@ RSpec.feature "Submitting Posts", type: :feature do
   end
 
   scenario "User 2 creates post on User 1's wall, post shows on User 1 wall" do
-    # create User 1
     sign_up
+    click_link "All Posts"
     click_link "New post"
     fill_in "Message", with: "Hello, this is user 1"
     click_button "Submit"
     click_link "Logout"
-    # create User 2
     sign_up_other_user
     click_link "All Posts"
-    # User 2 goes onto Wall of User 1
     click_link "test@gmail.com"
     click_link "New post"
     fill_in "Message", with: "This is user 2, posting on user 1's wall"
     click_button "Submit"
-    click_link "test@gmail.com"
     expect(page).to have_content("This is user 2, posting on user 1's wall")
     click_link "test_other@gmail.com"
     expect(page).not_to have_content("This is user 2, posting on user 1's wall")

--- a/spec/features/updating_post_spec.rb
+++ b/spec/features/updating_post_spec.rb
@@ -24,6 +24,19 @@ RSpec.feature "Updating posts", type: :feature do
     expect(page).to have_selector(:link_or_button, "Update")
   end
 
+  scenario "User CAN update on the global wall" do
+    sign_up
+    click_link "All Posts"
+    click_link "New post"
+    fill_in "Message", with: "Hello, world!"
+    click_button "Submit"
+    click_link "Update"
+    fill_in "Message", with: "Goodbye, world"
+    click_button "Submit"
+    expect(page).to have_content("Goodbye, world")
+    expect(page).not_to have_content("Hello, world")
+  end
+
   scenario "Users CAN only update their own post within limit of 10 minutes" do
     sign_up
     click_link "New post"


### PR DESCRIPTION
Posts now have a new attribute: wall_id
Wall id is passed from the wall which it was created at into the create method.
Users can post on other user's walls and they are displayed there.
Posts made on the global wall are only displayed there.
After Posting/Updating/Deleting you are returned to the wall where you made the action.